### PR TITLE
Exports PlotlyService within static forRoot() method.

### DIFF
--- a/src/app/plotly/plotly.module.ts
+++ b/src/app/plotly/plotly.module.ts
@@ -1,13 +1,19 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgModule, ModuleWithProviders } from "@angular/core";
+import { CommonModule } from "@angular/common";
 
-import { PlotComponent } from './plot/plot.component';
+import { PlotComponent } from "./plot/plot.component";
+import { PlotlyService } from "./plotly.service";
 
 @NgModule({
     imports: [CommonModule],
     declarations: [PlotComponent],
-    exports: [PlotComponent],
+    exports: [PlotComponent]
 })
 export class PlotlyModule {
-
+    static forRoot(): ModuleWithProviders {
+        return {
+            ngModule: PlotlyModule,
+            providers: [PlotlyService]
+        };
+    }
 }


### PR DESCRIPTION
The `PlotlyService` has not been exported under providers in the `PlotlyModule`. Therefore, whenever trying to inject the service, one will get an injection error. This pull request should fix this issue.