### PR TITLE
fixes #41: added missing plotly instance cleanup

### DIFF
--- a/src/app/shared/plotly.service.ts
+++ b/src/app/shared/plotly.service.ts
@@ -25,6 +25,7 @@ export class PlotlyService {
         const index = PlotlyService.instances.indexOf(div);
         if (index >= 0) {
             PlotlyService.instances.splice(index, 1);
+            PlotlyService._plotly.purge(div);
         }
     }
 


### PR DESCRIPTION
- added missing .purge() call when removing plotly instance
- added test to check that number of window events is stable
- added test to make sure the window resize handler is not called after a component is destroyed