### PR TITLE
Add the react event to the plot component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Event handlers for specific [`plotly.js` events](https://plot.ly/javascript/plot
 | `(hover)`                 | `Function` | `plotly_hover`                 |     |
 | `(legendClick)`           | `Function` | `plotly_legendclick`           |     |
 | `(legendDoubleClick)`     | `Function` | `plotly_legenddoubleclick`     |     |
+| `(react)`                 | `Function` | `plotly_react`                 |     |
 | `(relayout)`              | `Function` | `plotly_relayout`              |     |
 | `(restyle)`               | `Function` | `plotly_restyle`               |     |
 | `(redraw)`                | `Function` | `plotly_redraw`                |     |

--- a/src/app/shared/plot/plot.component.ts
+++ b/src/app/shared/plot/plot.component.ts
@@ -74,6 +74,7 @@ export class PlotComponent implements OnInit, OnChanges, OnDestroy, DoCheck {
     @Output() hover = new EventEmitter();
     @Output() legendClick = new EventEmitter();
     @Output() legendDoubleClick = new EventEmitter();
+    @Output() react = new EventEmitter();
     @Output() relayout = new EventEmitter();
     @Output() restyle = new EventEmitter();
     @Output() redraw = new EventEmitter();
@@ -91,7 +92,7 @@ export class PlotComponent implements OnInit, OnChanges, OnDestroy, DoCheck {
 
     public eventNames = ['afterExport', 'afterPlot', 'animated', 'animatingFrame', 'animationInterrupted', 'autoSize',
         'beforeExport', 'buttonClicked', 'clickAnnotation', 'deselect', 'doubleClick', 'framework', 'hover',
-        'legendClick', 'legendDoubleClick', 'relayout', 'restyle', 'redraw', 'selected', 'selecting', 'sliderChange',
+        'legendClick', 'legendDoubleClick', 'react', 'relayout', 'restyle', 'redraw', 'selected', 'selecting', 'sliderChange',
         'sliderEnd', 'sliderStart', 'transitioning', 'transitionInterrupted', 'unhover', 'relayouting', 'treemapclick',
         'sunburstclick'];
 


### PR DESCRIPTION
- Add the react event to the plot component to handle plotly_react events.
- Update the README.

I need this to know when the plot is done updating.

Linted, built, and tested
- Verified that the react event is fired when the plot is updated