### PR TITLE
plotly-plot template enhancements

### DIFF
--- a/projects/plotly/src/lib/plotly.component.ts
+++ b/projects/plotly/src/lib/plotly.component.ts
@@ -25,7 +25,7 @@ import { Plotly } from './plotly.interface';
 // @dynamic
 @Component({
     selector: 'plotly-plot',
-    template: `<div #plot [attr.id]="divId" [className]="getClassName()" [ngStyle]="style"></div>`,
+    template: `<div #plot [attr.id]="divId" [ngClass]="getClassName()" [ngStyle]="style"></div>`,
     providers: [PlotlyService],
 })
 export class PlotlyComponent implements OnInit, OnChanges, OnDestroy, DoCheck {

--- a/projects/plotly/src/lib/plotly.component.ts
+++ b/projects/plotly/src/lib/plotly.component.ts
@@ -25,7 +25,9 @@ import { Plotly } from './plotly.interface';
 // @dynamic
 @Component({
     selector: 'plotly-plot',
-    template: `<div #plot [attr.id]="divId" [ngClass]="getClassName()" [ngStyle]="style"></div>`,
+    template: `<div #plot [attr.id]="divId" [ngClass]="getClassName()" [ngStyle]="style">
+      <ng-content></ng-content>
+    </div>`,
     providers: [PlotlyService],
 })
 export class PlotlyComponent implements OnInit, OnChanges, OnDestroy, DoCheck {


### PR DESCRIPTION
  * use `[ngClass]` to manipulate the div classes. It's more compatible with the rest of Angular and doesn't overwrite classes set by e.g. directives.
  * add `<ng-content></ng-content>`, so that it's possible for the user to insert elements into plotly's div:
 ```
<plotly-plot>
   <div>user code</div>
</plotly-plot>
```
E.g. I'm using it to add loading overlay over the plot.