### PR TITLE
Suggested fix for #162

### DIFF
--- a/projects/plotly/src/lib/plotly.module.ts
+++ b/projects/plotly/src/lib/plotly.module.ts
@@ -27,6 +27,7 @@ export class PlotlyModule {
 
     private isValid(): boolean {
         return PlotlyModule.plotlyjs !== undefined
-            && typeof PlotlyModule.plotlyjs.plot === 'function';
+            && (typeof PlotlyModule.plotlyjs.plot === 'function'
+                || typeof PlotlyModule.plotlyjs.newPlot === 'function');
     }
 }

--- a/projects/plotly/src/lib/plotly.service.ts
+++ b/projects/plotly/src/lib/plotly.service.ts
@@ -95,10 +95,20 @@ export class PlotlyService {
     public plot(div: Plotly.PlotlyHTMLElement, data: Plotly.Data[], layout?: Partial<Plotly.Layout>, config?: Partial<Plotly.Config>, frames?: Partial<Plotly.Config>[]): Promise<any>  {
         if (frames) {
             const obj = {data, layout, config, frames};
-            return this._getPlotly().plot(div, obj) as Promise<any>;
+            if (typeOf(this.__getPlotly.plot === 'function')) {
+                return this._getPlotly().plot(div, obj) as Promise<any>;
+            } else {
+                // Adds support for Plotly 2.0.0 release candidates
+                return this._getPlotly().newPlot(div, obj) as Promise<any>;
+            }
         }
 
-        return this._getPlotly().plot(div, data, layout, config) as Promise<any>;
+        if (typeOf(this.__getPlotly.plot === 'function')) {
+            return this._getPlotly().plot(div, data, layout, config) as Promise<any>;
+        } else {
+            // Adds support for Plotly 2.0.0 release candidates
+            return this._getPlotly().newPlot(div, data, layout, config) as Promise<any>;
+        }
     }
 
     public update(div: Plotly.PlotlyHTMLElement, data: Plotly.Data[], layout?: Partial<Plotly.Layout>, config?: Partial<Plotly.Config>, frames?: Partial<Plotly.Config>[]): Promise<any>  {


### PR DESCRIPTION
Adds support for Plotly 2.0.0-rcX by selecting either `Plotly.plot(...)` or `Plotly.newPlot(...)` based on availability. 

Fixes #162 