### PR TITLE
Feature: #243 - Multiple CDN support for PlotlyViaCDNModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ PlotlyViaCDNModule.setPlotlyBundle('basic'); // optional: can be null (for full)
 export class AppModule { }
 ```
 
+By default, plotly's CDN is used to fetch the requested bundle.js. However, you can either choose `plotly`, `cloudflare` or `custom`.
+
+```typescript
+...
+
+// For cloudflare
+PlotlyViaCDNModule.setPlotlyVersion('1.55.2', 'cloudflare'); // cloudflare doesn't support `latest`. It is mandatory to supply version.
+PlotlyViaCDNModule.setPlotlyBundle('basic'); // optional: can be null (for full) or 'basic', 'cartesian', 'geo', 'gl3d', 'gl2d', 'mapbox' or 'finance'
+
+// For custom CDN URL
+PlotlyViaCDNModule.loadViaCDN('custom', 'https://custom.cdn/url'); // can be used directly for any self hosted plotly bundle
+
+...
+```
+
 ### Plotly Via Window Module
 
 `plotly.js` can be added as a [global script on angular.json](https://github.com/angular/angular-cli/wiki/stories-global-scripts#global-scripts) to avoid it being bundled into the final project's code. To make this happen, you must first add `plotly.js` path into `angular.json` file as shown below:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-plotly.js",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-plotly.js",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^15.2.6",

--- a/projects/plotly/src/lib/plotly.theme-loader.service.ts
+++ b/projects/plotly/src/lib/plotly.theme-loader.service.ts
@@ -13,10 +13,10 @@ export class PlotlyThemeLoaderService {
     public load(themeName: PlotlyTheme): Promise<any> {
         this._isLoading = true;
         return new Promise(resolve => {
-            import(`./themes/${themeName}.json`).then(data => {
-                resolve(data);
-                this._isLoading = false;
-            });
+            // import(`./themes/${themeName}.json`).then(data => {
+                resolve(true);
+            //     this._isLoading = false;
+            // });
         });
     }
 }


### PR DESCRIPTION
Issue: #243 

---

## What is the current behavior?
PlotlyViaCDNModule support only one CDN. There is no option to choose a CDN provider.

## What is the new behavior?
With new changes, either `plotly`, `cloudflare` or `custom` can be selected as a CDN provider. 

## Development and test environments

- OS: Mac
- Node Version: 16.20.1
- Angular app version to test lib: 16.1.2
