### PR TITLE
Fix: #198 - Error thrown in ngOnDestroy if plot not yet initialized

### DIFF
--- a/projects/plotly/src/lib/plotly.component.spec.ts
+++ b/projects/plotly/src/lib/plotly.component.spec.ts
@@ -242,4 +242,9 @@ describe('PlotlyComponent', () => {
         expect(component.loadTheme).not.toHaveBeenCalled();
         expect(component.themeLoader.load).not.toHaveBeenCalledOnceWith('plotly_dark');
     });
+
+    it('should not cause errors if ngOnDestroy is called before plotly is initialized', () => {
+        // note that this test intentionally does not call ngOnInit/whenStable
+        expect(() => component.ngOnDestroy()).not.toThrow();
+    });
 });

--- a/projects/plotly/src/lib/plotly.component.ts
+++ b/projects/plotly/src/lib/plotly.component.ts
@@ -143,9 +143,11 @@ export class PlotlyComponent implements OnInit, OnChanges, OnDestroy, DoCheck {
             this.resizeHandler = undefined;
         }
 
-        const figure = this.createFigure();
-        this.purge.emit(figure);
-        PlotlyService.remove(this.plotlyInstance!);
+        if (this.plotlyInstance) {
+            const figure = this.createFigure();
+            this.purge.emit(figure);
+            PlotlyService.remove(this.plotlyInstance);
+        }
     }
 
     ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
This can occur in unit tests if you do not await the component being stable, so this resolves #198. However, this could also happen if ngOnDestroy is called very quickly after ngOnInit.

Note that the actual error happens inside createFigure, but given that the `PlotlyService.remove` call needs the `plotlyInstance` as well, and that other code checks `plotlyInstance` for truthiness first, this seemed like a reasonable seam to introduce this check.

The provided unit test failed before making this change, so this PR was done via TDD.

One bonus of this change is that it removes a use of the `!` operator.