### PR TITLE
Added null definition to setPlotlyBundle method

### DIFF
--- a/projects/plotly/src/lib/plotly-via-cdn.module.ts
+++ b/projects/plotly/src/lib/plotly-via-cdn.module.ts
@@ -33,7 +33,7 @@ export class PlotlyViaCDNModule {
         PlotlyViaCDNModule.plotlyVersion = version;
     }
 
-    public static setPlotlyBundle(bundle: PlotlyBundleName): void {
+    public static setPlotlyBundle(bundle: PlotlyBundleName | null): void {
         const isOk = bundle === null || PlotlyViaCDNModule.plotlyBundleNames.indexOf(bundle) >= 0;
         if (!isOk) {
             const names = PlotlyViaCDNModule.plotlyBundleNames.map(n => `"${n}"`).join(', ');


### PR DESCRIPTION
This should fix the error `Argument of type 'null' is not assignable to parameter of type 'PlotlyBundleName'` on the setPlotlyBundle method. This came up after updating Typescript to 5.1 from 5.0.

This is my first PR... wasn't sure if I should've create an issue first. Let me know if I need to :smile: