### PR TITLE
fix: add innerStyle compatibility input for Angular 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [20.0.2] - 2026-08-20
+### Fixed
+- Added `[innerStyle]` as the preferred plot container styling input while
+  retaining `[style]` as a deprecated compatibility alias.
+
+
 ## [20.0.1] - 2026-08-20
 ### Fixed
 - Exported the documented CDN/window modules and Plotly public types.

--- a/README.md
+++ b/README.md
@@ -122,18 +122,19 @@ For a full description of Plotly chart types and attributes see the following re
 | `(error)`                  | `Function(err)`              | `undefined`                                       | Callback executed when a plotly.js API method rejects                                                                                                                 |
 | `[divId]`                  | `string`                     | `undefined`                                       | id assigned to the `<div>` into which the plot is rendered.                                                                                                           |
 | `[className]`              | `string`                     | `undefined`                                       | applied to the `<div>` into which the plot is rendered                                                                                                                |
-| `[style]`                  | `Object`                     | `{position: 'relative', display: 'inline-block'}` | used to style the `<div>` into which the plot is rendered                                                                                                             |
+| `[innerStyle]`             | `Object`                     | `{position: 'relative', display: 'inline-block'}` | used to style the `<div>` into which the plot is rendered                                                                                                             |
+| `[style]`                  | `Object`                     | `undefined`                                       | deprecated compatibility alias for `[innerStyle]`                                                                                                                     |
 | `[debug]`                  | `Boolean`                    | `false`                                           | Assign the graph div to `window.gd` for debugging                                                                                                                     |
 | `[useResizeHandler]`       | `Boolean`                    | `false`                                           | When true, adds a call to `Plotly.Plot.resize()` as a `window.resize` event handler                                                                                   |
 
-**Note**: To make a plot responsive, i.e. to fill its containing element and resize when the window is resized, use `style` or `className` to set the dimensions of the element (i.e. using `width: 100%; height: 100%` or some similar values) and set `useResizeHandler` to `true` while setting `layout.autosize` to `true` and leaving `layout.height` and `layout.width` undefined. This will implement the behaviour documented here: https://plot.ly/javascript/responsive-fluid-layout/
+**Note**: To make a plot responsive, i.e. to fill its containing element and resize when the window is resized, use `innerStyle` or `className` to set the dimensions of the element (i.e. using `width: 100%; height: 100%` or some similar values) and set `useResizeHandler` to `true` while setting `layout.autosize` to `true` and leaving `layout.height` and `layout.width` undefined. This will implement the behaviour documented here: https://plot.ly/javascript/responsive-fluid-layout/
 
 ```typescript
 @Component({
     selector: 'plotly-example',
     template: `
     <plotly-plot [data]="graph.data" [layout]="graph.layout"
-       [useResizeHandler]="true" [style]="{position: 'relative', width: '100%', height: '100%'}">
+       [useResizeHandler]="true" [innerStyle]="{position: 'relative', width: '100%', height: '100%'}">
     </plotly-plot>`,
 })
 export class PlotlyExampleComponent {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-plotly.js",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-plotly.js",
-      "version": "20.0.1",
+      "version": "20.0.2",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "20.3.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-plotly.js",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/projects/plotly/package.json
+++ b/projects/plotly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-plotly.js",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": ">=20.0.0 <21.0.0",

--- a/projects/plotly/src/lib/plotly.component.spec.ts
+++ b/projects/plotly/src/lib/plotly.component.spec.ts
@@ -41,10 +41,23 @@ describe('PlotlyComponent', () => {
         expect(component.plotEl.nativeElement).toBeDefined();
     });
 
-    it('should receive the style from the property', () => {
+    it('should receive the inner style from the property', () => {
+        componentRef.setInput('innerStyle', { 'background-color': 'red' });
+        fixture.detectChanges();
+        expect(component.plotEl.nativeElement.style.backgroundColor).toBe('red');
+    });
+
+    it('should retain style as a deprecated compatibility alias', () => {
         componentRef.setInput('style', { 'background-color': 'red' });
         fixture.detectChanges();
         expect(component.plotEl.nativeElement.style.backgroundColor).toBe('red');
+    });
+
+    it('should prefer innerStyle when both style inputs are provided', () => {
+        componentRef.setInput('style', { 'background-color': 'red' });
+        componentRef.setInput('innerStyle', { 'background-color': 'blue' });
+        fixture.detectChanges();
+        expect(component.plotEl.nativeElement.style.backgroundColor).toBe('blue');
     });
 
     it('should add the id in the #plotEl', () => {

--- a/projects/plotly/src/lib/plotly.component.ts
+++ b/projects/plotly/src/lib/plotly.component.ts
@@ -29,7 +29,7 @@ import { Plotly } from './plotly.interface';
     selector: 'plotly-plot',
     standalone: true,
     imports: [CommonModule],
-    template: `<div #plot [attr.id]="divId()" [ngClass]="getClassName()" [ngStyle]="style()">
+    template: `<div #plot [attr.id]="divId()" [ngClass]="getClassName()" [ngStyle]="innerStyle() ?? style()">
       <ng-content></ng-content>
     </div>`,
     providers: [PlotlyService],
@@ -49,6 +49,10 @@ export class PlotlyComponent implements OnInit, OnChanges, OnDestroy, DoCheck {
     layout = input<Partial<Plotly.Layout>>();
     config = input<Partial<Plotly.Config>>();
     frames = input<Partial<Plotly.Config>[]>();
+    innerStyle = input<{ [key: string]: string }>();
+    /**
+     * @deprecated Use `innerStyle` to avoid conflicting with Angular's global style binding.
+     */
     style = input<{ [key: string]: string }>();
 
     divId = input<string>();


### PR DESCRIPTION
Backports #289 to the Angular 20 maintenance line.\n\n- adds `[innerStyle]` as the preferred styling input\n- retains `[style]` as a deprecated compatibility alias\n- adds alias and precedence tests\n- prepares version 20.0.2 and updates the changelog\n\nThe code backport retains cherry-pick provenance from the merged contributor PR.