### PR TITLE
chore: prepare angular-plotly.js 22.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [22.0.1] - 2026-08-20
+### Fixed
+- Added `[innerStyle]` as the preferred plot container styling input while
+  retaining `[style]` as a deprecated compatibility alias.
+
+
 ## [22.0.0] - 2026-08-20
 ### Changed
 - Added Angular 22 support using the official Angular 21→22 migrations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-plotly.js",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-plotly.js",
-      "version": "22.0.0",
+      "version": "22.0.1",
       "license": "MIT",
       "dependencies": {
         "@angular/common": "22.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-plotly.js",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/projects/plotly/package.json
+++ b/projects/plotly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-plotly.js",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": ">=22.0.0 <23.0.0",


### PR DESCRIPTION
Prepares the Angular 22 patch release for the backward-compatible `[innerStyle]` input merged in #289.\n\n- synchronizes root, library, and lockfile versions at 22.0.1\n- documents the fix in the changelog\n- preserves the `angular22` publish tag; `latest` promotion remains a separate verified release step