### PR TITLE
Coordinate supported dependency major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "plotly.js-dist"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "jasmine-core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/jasmine"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: /
     target-branch: v20
@@ -60,6 +66,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "zone.js"
         update-types: ["version-update:semver-minor"]
+      - dependency-name: "jasmine-core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/jasmine"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: /
     target-branch: v21
@@ -88,4 +100,10 @@ updates:
       - dependency-name: "typescript-eslint"
         update-types: ["version-update:semver-major"]
       - dependency-name: "plotly.js-dist"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jasmine-core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/jasmine"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,12 @@
         "@angular/compiler": "22.1.3",
         "@angular/compiler-cli": "22.1.3",
         "@eslint/js": "10.0.1",
-        "@types/jasmine": "5.1.9",
+        "@types/jasmine": "6.0.0",
         "@types/node": "24.10.1",
         "angular-eslint": "22.1.0",
         "eslint": "10.8.1",
         "istanbul-lib-instrument": "6.0.3",
-        "jasmine-core": "5.10.0",
+        "jasmine-core": "6.3.0",
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.2.0",
         "karma-coverage": "2.2.1",
@@ -5072,9 +5072,9 @@
       "license": "MIT"
     },
     "node_modules/@types/jasmine": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.9.tgz",
-      "integrity": "sha512-8t4HtkW4wxiPVedMpeZ63n3vlWxEIquo/zc1Tm8ElU+SqVV7+D3Na2PWaJUp179AzTragMWVwkMv7mvty0NfyQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-6.0.0.tgz",
+      "integrity": "sha512-18lgGsLmEh3VJk9eZ5wAjTISxdqzl6YOwu8UdMpolajN57QOCNbl+AbHUd+Yu9ItrsFdB+c8LSZSGNg8nHaguw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8159,9 +8159,9 @@
       }
     },
     "node_modules/jasmine-core": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.10.0.tgz",
-      "integrity": "sha512-MrChbWV5LBo+EaeKwTM1eZ6oYSz1brvFExnRafraEkJkbJ9evbUxABhnIgGQimhpMxhg+BD6QmOvb/e3NXsNdg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "@angular/compiler": "22.1.3",
     "@angular/compiler-cli": "22.1.3",
     "@eslint/js": "10.0.1",
-    "@types/jasmine": "5.1.9",
+    "@types/jasmine": "6.0.0",
     "@types/node": "24.10.1",
     "angular-eslint": "22.1.0",
     "eslint": "10.8.1",
     "istanbul-lib-instrument": "6.0.3",
-    "jasmine-core": "5.10.0",
+    "jasmine-core": "6.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",
     "karma-coverage": "2.2.1",
@@ -48,5 +48,5 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
-  "packageManager": "npm@11.6.0"
+  "packageManager": "npm@11.12.1"
 }


### PR DESCRIPTION
## Summary
- upgrade jasmine-core to 6.3.0 and @types/jasmine to 6.0.0 as a compatible pair
- align packageManager with the npm 11.12.1 version used by CI
- defer major updates for Jasmine and Node typings across supported branches

## Rationale
Jasmine 7 is incompatible with the Zone.js Jasmine patch used by the current Karma test setup. Node 26 typings are also deferred until Node 26 becomes part of the tested runtime policy.

## Validation
- clean npm ci with Node 24.15.0 and npm 11.12.1
- npm run lint
- npm test
- npm run build:demo
- npm audit --omit=dev --audit-level=high
- npm run verify:package
- npm run verify:consumer