### PR TITLE
Align v20 npm metadata with CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
-  "packageManager": "npm@11.6.0"
+  "packageManager": "npm@11.12.1"
 }


### PR DESCRIPTION
## Summary
- align packageManager with npm 11.12.1 used by CI
- retain Jasmine 5 because v20 remains on Zone.js 0.15

## Validation
- clean npm ci with Node 24.15.0 and npm 11.12.1
- npm run lint
- npm test
- npm run build:demo
- npm audit --omit=dev --audit-level=high
- npm run verify:package
- npm run verify:consumer